### PR TITLE
Refactor task metadata handling in webhook schemas and GoogleTasksService

### DIFF
--- a/api/handlers/webhook.ts
+++ b/api/handlers/webhook.ts
@@ -32,9 +32,10 @@ export function createCreateTaskWebhookHandler(
         payload.title,
         payload.notes,
         payload.due,
-        payload.starred,
-        payload.parent,
-        payload.url
+        payload.priority,
+        payload.isFlagged,
+        payload.url,
+        payload.tags
       );
 
       return c.json(
@@ -65,25 +66,24 @@ export function createUpdateTaskWebhookHandler(
   ) {
     const { userId } = c.req.valid('param');
     const payload = c.req.valid('json');
-    const { taskId, ...updateData } = payload;
 
-    console.log('Updating task:', { userId, taskId });
-    console.log('Update payload:', updateData);
+    console.log('Updating task for userId:', userId);
+    console.log('Update payload:', payload);
 
     try {
       const accessToken = await userService.getAccessToken(userId);
-
-      const task = await googleTasksService.updateTask(accessToken, taskId, {
-        title: updateData.title,
-        notes: updateData.notes,
-        due: updateData.due,
-        status: updateData.status,
-        starred: updateData.starred,
-        parent: updateData.parent,
-        links: updateData.url
-          ? [{ type: 'url', description: 'Link', link: updateData.url }]
-          : updateData.links,
-      });
+      const task = await googleTasksService.updateTask(
+        accessToken,
+        payload.taskId,
+        payload.title,
+        payload.notes,
+        payload.due,
+        payload.status,
+        payload.priority,
+        payload.isFlagged,
+        payload.url,
+        payload.tags
+      );
 
       return c.json(
         {

--- a/api/handlers/webhook.ts
+++ b/api/handlers/webhook.ts
@@ -79,13 +79,17 @@ export function createUpdateTaskWebhookHandler(
       if (payload.notes !== undefined) updates.notes = payload.notes;
       if (payload.due !== undefined) updates.due = payload.due;
       if (payload.status !== undefined) updates.status = payload.status;
+      if (payload.priority !== undefined) updates.priority = payload.priority;
+      if (payload.isFlagged !== undefined)
+        updates.isFlagged = payload.isFlagged;
+      if (payload.url !== undefined) updates.url = payload.url;
+      if (payload.tags !== undefined) updates.tags = payload.tags;
 
       const task = await googleTasksService.updateTask(
         accessToken,
         payload.taskId,
         updates
       );
-
       return c.json(
         {
           message: 'Task updated successfully.',

--- a/api/handlers/webhook.ts
+++ b/api/handlers/webhook.ts
@@ -1,6 +1,7 @@
 import type { Context } from 'hono';
 import type { GoogleTasksService } from '../services/google-tasks';
 import type { UserService } from '../services/user';
+import type { UpdateTaskRequest } from '../types/google-api';
 import type {
   CreateTaskWebhookBody,
   UpdateTaskWebhookBody,
@@ -72,17 +73,17 @@ export function createUpdateTaskWebhookHandler(
 
     try {
       const accessToken = await userService.getAccessToken(userId);
+
+      const updates: UpdateTaskRequest = {};
+      if (payload.title !== undefined) updates.title = payload.title;
+      if (payload.notes !== undefined) updates.notes = payload.notes;
+      if (payload.due !== undefined) updates.due = payload.due;
+      if (payload.status !== undefined) updates.status = payload.status;
+
       const task = await googleTasksService.updateTask(
         accessToken,
         payload.taskId,
-        payload.title,
-        payload.notes,
-        payload.due,
-        payload.status,
-        payload.priority,
-        payload.isFlagged,
-        payload.url,
-        payload.tags
+        updates
       );
 
       return c.json(

--- a/api/handlers/webhook.ts
+++ b/api/handlers/webhook.ts
@@ -1,7 +1,6 @@
 import type { Context } from 'hono';
 import type { GoogleTasksService } from '../services/google-tasks';
 import type { UserService } from '../services/user';
-import type { UpdateTaskRequest } from '../types/google-api';
 import type {
   CreateTaskWebhookBody,
   UpdateTaskWebhookBody,
@@ -74,20 +73,11 @@ export function createUpdateTaskWebhookHandler(
     try {
       const accessToken = await userService.getAccessToken(userId);
 
-      const updates: UpdateTaskRequest = {};
-      if (payload.title !== undefined) updates.title = payload.title;
-      if (payload.notes !== undefined) updates.notes = payload.notes;
-      if (payload.due !== undefined) updates.due = payload.due;
-      if (payload.status !== undefined) updates.status = payload.status;
-      if (payload.priority !== undefined) updates.priority = payload.priority;
-      if (payload.isFlagged !== undefined)
-        updates.isFlagged = payload.isFlagged;
-      if (payload.url !== undefined) updates.url = payload.url;
-      if (payload.tags !== undefined) updates.tags = payload.tags;
+      const { taskId, ...updates } = payload;
 
       const task = await googleTasksService.updateTask(
         accessToken,
-        payload.taskId,
+        taskId,
         updates
       );
       return c.json(

--- a/api/index.ts
+++ b/api/index.ts
@@ -94,18 +94,10 @@ const createTaskWebhookBodySchema = z.object({
   title: z.string().min(1).trim(),
   notes: z.string().trim().optional(),
   due: z.string().optional(),
-  starred: z.boolean().optional(),
-  parent: z.string().trim().optional(),
+  priority: z.number().min(0).max(9).optional(),
+  isFlagged: z.boolean().optional(),
   url: z.string().url().optional(),
-  links: z
-    .array(
-      z.object({
-        type: z.string(),
-        description: z.string(),
-        link: z.string().url(),
-      })
-    )
-    .optional(),
+  tags: z.array(z.string()).optional(),
 });
 
 const updateTaskWebhookBodySchema = z.object({
@@ -114,18 +106,10 @@ const updateTaskWebhookBodySchema = z.object({
   notes: z.string().trim().optional(),
   due: z.string().optional(),
   status: z.enum(['needsAction', 'completed']).optional(),
-  starred: z.boolean().optional(),
-  parent: z.string().trim().optional(),
+  priority: z.number().min(0).max(9).optional(),
+  isFlagged: z.boolean().optional(),
   url: z.string().url().optional(),
-  links: z
-    .array(
-      z.object({
-        type: z.string(),
-        description: z.string(),
-        link: z.string().url(),
-      })
-    )
-    .optional(),
+  tags: z.array(z.string()).optional(),
 });
 
 const deleteTaskWebhookBodySchema = z.object({

--- a/api/services/google-tasks.ts
+++ b/api/services/google-tasks.ts
@@ -29,28 +29,23 @@ function buildNotesWithMetadata(
   let finalNotes = notes || '';
   const metadataLines: string[] = [];
 
-  // Add priority to metadata
   if (metadata.priority !== undefined) {
     metadataLines.push(`Priority: ${metadata.priority}`);
   }
 
-  // Add flagged status to metadata
   if (metadata.isFlagged !== undefined) {
     metadataLines.push(`Flagged: ${metadata.isFlagged ? 'Yes' : 'No'}`);
   }
 
-  // Add URL to metadata
   if (metadata.url) {
     metadataLines.push(`URL: ${metadata.url}`);
   }
 
-  // Add tags to metadata
   if (metadata.tags && metadata.tags.length > 0) {
     const tagsString = metadata.tags.map((tag) => `#${tag}`).join(' ');
     metadataLines.push(`Tags: ${tagsString}`);
   }
 
-  // Append all metadata to notes
   if (metadataLines.length > 0) {
     const metadataSection = metadataLines.join('\n');
     finalNotes = finalNotes
@@ -121,7 +116,6 @@ export class GoogleTasksService {
       title: title || 'New Reminder',
     };
 
-    // Build notes with metadata
     const finalNotes = buildNotesWithMetadata(notes, {
       priority,
       isFlagged,
@@ -262,78 +256,12 @@ export class GoogleTasksService {
     return tasksList;
   }
 
-  /**
-   * Update a task using individual parameters (simplified interface)
-   */
-  async updateTask(
-    accessToken: string,
-    taskId: string,
-    title?: string,
-    notes?: string,
-    due?: string,
-    status?: 'needsAction' | 'completed',
-    priority?: number,
-    isFlagged?: boolean,
-    url?: string,
-    tags?: string[],
-    etag?: string
-  ): Promise<GoogleTask>;
-
-  /**
-   * Update a task using UpdateTaskRequest object (original interface)
-   */
   async updateTask(
     accessToken: string,
     taskId: string,
     updates: UpdateTaskRequest,
     etag?: string
-  ): Promise<GoogleTask>;
-
-  async updateTask(
-    accessToken: string,
-    taskId: string,
-    titleOrUpdates?: string | UpdateTaskRequest,
-    notesOrEtag?: string,
-    due?: string,
-    status?: 'needsAction' | 'completed',
-    priority?: number,
-    isFlagged?: boolean,
-    url?: string,
-    tags?: string[],
-    etag?: string
   ): Promise<GoogleTask> {
-    // Handle overloaded parameters
-    let updates: UpdateTaskRequest;
-    let finalEtag: string | undefined;
-
-    if (typeof titleOrUpdates === 'object') {
-      // Called with UpdateTaskRequest object
-      updates = titleOrUpdates;
-      finalEtag = notesOrEtag; // In this case, notesOrEtag is the etag
-    } else {
-      // Called with individual parameters
-      updates = {};
-      if (titleOrUpdates !== undefined) updates.title = titleOrUpdates;
-
-      // Build notes with metadata if needed
-      const hasMetadata =
-        priority !== undefined ||
-        isFlagged !== undefined ||
-        url !== undefined ||
-        (tags && tags.length > 0);
-      if (notesOrEtag !== undefined || hasMetadata) {
-        updates.notes = buildNotesWithMetadata(notesOrEtag, {
-          priority,
-          isFlagged,
-          url,
-          tags,
-        });
-      }
-
-      if (due !== undefined) updates.due = due;
-      if (status !== undefined) updates.status = status;
-      finalEtag = etag;
-    }
 
     const taskData: UpdateTaskRequest = {};
 
@@ -355,8 +283,8 @@ export class GoogleTasksService {
       Accept: 'application/json',
     };
 
-    if (finalEtag) {
-      headers['If-Match'] = finalEtag;
+    if (etag) {
+      headers['If-Match'] = etag;
     }
 
     console.log('🔵 Google Tasks API Request (updateTask):', {

--- a/api/services/google-tasks.ts
+++ b/api/services/google-tasks.ts
@@ -9,34 +9,128 @@ const TASKS_API_BASE_URL = 'https://tasks.googleapis.com/tasks/v1';
 const DEFAULT_TASK_LIST = '@default';
 const MAX_PAGE_SIZE = 100;
 
+interface TaskMetadata {
+  priority?: number;
+  isFlagged?: boolean;
+  url?: string;
+  tags?: string[];
+}
+
+/**
+ * Builds the final notes string with metadata appended in a structured format
+ * @param notes - The original notes content
+ * @param metadata - The metadata to append
+ * @returns The final notes string with metadata section
+ */
+function buildNotesWithMetadata(
+  notes: string | undefined,
+  metadata: TaskMetadata
+): string {
+  let finalNotes = notes || '';
+  const metadataLines: string[] = [];
+
+  // Add priority to metadata
+  if (metadata.priority !== undefined) {
+    metadataLines.push(`Priority: ${metadata.priority}`);
+  }
+
+  // Add flagged status to metadata
+  if (metadata.isFlagged !== undefined) {
+    metadataLines.push(`Flagged: ${metadata.isFlagged ? 'Yes' : 'No'}`);
+  }
+
+  // Add URL to metadata
+  if (metadata.url) {
+    metadataLines.push(`URL: ${metadata.url}`);
+  }
+
+  // Add tags to metadata
+  if (metadata.tags && metadata.tags.length > 0) {
+    const tagsString = metadata.tags.map((tag) => `#${tag}`).join(' ');
+    metadataLines.push(`Tags: ${tagsString}`);
+  }
+
+  // Append all metadata to notes
+  if (metadataLines.length > 0) {
+    const metadataSection = metadataLines.join('\n');
+    finalNotes = finalNotes
+      ? `${finalNotes}\n\n--- Metadata ---\n${metadataSection}`
+      : `--- Metadata ---\n${metadataSection}`;
+  }
+
+  return finalNotes;
+}
+
+/**
+ * Extracts metadata from notes that were formatted with buildNotesWithMetadata
+ * @param notes - The notes string containing metadata
+ * @returns The extracted metadata and the original notes without metadata
+ */
+function extractMetadataFromNotes(notes: string): {
+  originalNotes: string;
+  metadata: TaskMetadata;
+} {
+  const metadataMarker = '--- Metadata ---';
+  const metadataIndex = notes.lastIndexOf(metadataMarker);
+
+  if (metadataIndex === -1) {
+    return { originalNotes: notes, metadata: {} };
+  }
+
+  const originalNotes = notes.substring(0, metadataIndex).trim();
+  const metadataSection = notes
+    .substring(metadataIndex + metadataMarker.length)
+    .trim();
+
+  const metadata: TaskMetadata = {};
+  const lines = metadataSection.split('\n');
+
+  for (const line of lines) {
+    const trimmedLine = line.trim();
+
+    if (trimmedLine.startsWith('Priority: ')) {
+      metadata.priority = parseInt(trimmedLine.substring(10), 10);
+    } else if (trimmedLine.startsWith('Flagged: ')) {
+      metadata.isFlagged = trimmedLine.substring(9) === 'Yes';
+    } else if (trimmedLine.startsWith('URL: ')) {
+      metadata.url = trimmedLine.substring(5);
+    } else if (trimmedLine.startsWith('Tags: ')) {
+      const tagsString = trimmedLine.substring(6);
+      metadata.tags = tagsString
+        .split(' ')
+        .filter((tag) => tag.startsWith('#'))
+        .map((tag) => tag.substring(1));
+    }
+  }
+
+  return { originalNotes, metadata };
+}
+
 export class GoogleTasksService {
   async createTask(
     accessToken: string,
     title: string,
     notes?: string,
     due?: string,
-    starred?: boolean,
-    parent?: string,
-    url?: string
+    priority?: number,
+    isFlagged?: boolean,
+    url?: string,
+    tags?: string[]
   ): Promise<GoogleTask> {
     const taskData: CreateTaskRequest = {
       title: title || 'New Reminder',
     };
 
-    if (url) {
-      taskData.links = [
-        {
-          type: 'url',
-          description: 'Link',
-          link: url,
-        },
-      ];
-    }
+    // Build notes with metadata
+    const finalNotes = buildNotesWithMetadata(notes, {
+      priority,
+      isFlagged,
+      url,
+      tags,
+    });
 
-    if (notes) taskData.notes = notes;
+    if (finalNotes) taskData.notes = finalNotes;
     if (due) taskData.due = due;
-    if (starred !== undefined) taskData.starred = starred;
-    if (parent) taskData.parent = parent;
 
     const requestUrl = new URL(
       `${TASKS_API_BASE_URL}/lists/${DEFAULT_TASK_LIST}/tasks`
@@ -168,12 +262,79 @@ export class GoogleTasksService {
     return tasksList;
   }
 
+  /**
+   * Update a task using individual parameters (simplified interface)
+   */
+  async updateTask(
+    accessToken: string,
+    taskId: string,
+    title?: string,
+    notes?: string,
+    due?: string,
+    status?: 'needsAction' | 'completed',
+    priority?: number,
+    isFlagged?: boolean,
+    url?: string,
+    tags?: string[],
+    etag?: string
+  ): Promise<GoogleTask>;
+
+  /**
+   * Update a task using UpdateTaskRequest object (original interface)
+   */
   async updateTask(
     accessToken: string,
     taskId: string,
     updates: UpdateTaskRequest,
     etag?: string
+  ): Promise<GoogleTask>;
+
+  async updateTask(
+    accessToken: string,
+    taskId: string,
+    titleOrUpdates?: string | UpdateTaskRequest,
+    notesOrEtag?: string,
+    due?: string,
+    status?: 'needsAction' | 'completed',
+    priority?: number,
+    isFlagged?: boolean,
+    url?: string,
+    tags?: string[],
+    etag?: string
   ): Promise<GoogleTask> {
+    // Handle overloaded parameters
+    let updates: UpdateTaskRequest;
+    let finalEtag: string | undefined;
+
+    if (typeof titleOrUpdates === 'object') {
+      // Called with UpdateTaskRequest object
+      updates = titleOrUpdates;
+      finalEtag = notesOrEtag; // In this case, notesOrEtag is the etag
+    } else {
+      // Called with individual parameters
+      updates = {};
+      if (titleOrUpdates !== undefined) updates.title = titleOrUpdates;
+
+      // Build notes with metadata if needed
+      const hasMetadata =
+        priority !== undefined ||
+        isFlagged !== undefined ||
+        url !== undefined ||
+        (tags && tags.length > 0);
+      if (notesOrEtag !== undefined || hasMetadata) {
+        updates.notes = buildNotesWithMetadata(notesOrEtag, {
+          priority,
+          isFlagged,
+          url,
+          tags,
+        });
+      }
+
+      if (due !== undefined) updates.due = due;
+      if (status !== undefined) updates.status = status;
+      finalEtag = etag;
+    }
+
     const taskData: UpdateTaskRequest = {};
 
     if (updates.title !== undefined) taskData.title = updates.title;
@@ -187,9 +348,6 @@ export class GoogleTasksService {
       }
     }
     if (updates.completed !== undefined) taskData.completed = updates.completed;
-    if (updates.starred !== undefined) taskData.starred = updates.starred;
-    if (updates.parent !== undefined) taskData.parent = updates.parent;
-    if (updates.links !== undefined) taskData.links = updates.links;
 
     const headers: Record<string, string> = {
       Authorization: `Bearer ${accessToken}`,
@@ -197,8 +355,8 @@ export class GoogleTasksService {
       Accept: 'application/json',
     };
 
-    if (etag) {
-      headers['If-Match'] = etag;
+    if (finalEtag) {
+      headers['If-Match'] = finalEtag;
     }
 
     console.log('🔵 Google Tasks API Request (updateTask):', {

--- a/api/services/google-tasks.ts
+++ b/api/services/google-tasks.ts
@@ -90,9 +90,13 @@ function extractMetadataFromNotes(notes: string): {
     const value = trimmedLine.substring(separatorIndex + 1).trim();
 
     switch (key) {
-      case 'Priority':
-        metadata.priority = parseInt(value, 10);
+      case 'Priority': {
+        const parsedPriority = parseInt(value, 10);
+        if (!isNaN(parsedPriority)) {
+          metadata.priority = parsedPriority;
+        }
         break;
+      }
       case 'Flagged':
         metadata.isFlagged = value === 'Yes';
         break;

--- a/api/types/google-api.ts
+++ b/api/types/google-api.ts
@@ -16,14 +16,6 @@ export interface GoogleTaskData {
   title: string;
   notes?: string;
   due?: string; // RFC 3339 timestamp. Absence of time means it's an all-day task.
-
-  /**
-   * @description Represents a "starred" task in Google Tasks.
-   * This is the closest equivalent to Apple Reminders' "isFlagged".
-   * It's a boolean, not a graded scale.
-   * Sync Strategy: Map this to Apple Reminders' isFlagged property.
-   */
-  starred?: boolean;
 }
 
 /**
@@ -81,15 +73,7 @@ export interface GoogleTasksListResponse {
  * Inherits user-editable fields and adds properties available at creation time.
  */
 export interface CreateTaskRequest extends GoogleTaskData {
-  /**
-   * @description The ID of the parent task under which to create this subtask.
-   */
-  parent?: string;
-
-  /**
-   * @description Links associated with the task.
-   */
-  links?: GoogleLink[];
+  // All metadata (priority, isFlagged, url, tags) is now stored in the notes field
 }
 
 /**
@@ -109,23 +93,7 @@ export interface UpdateTaskRequest {
    */
   completed?: string;
 
-  /**
-   * @description Set to `true` or `false` to star or unstar the task.
-   * Used to sync priority/flagged status.
-   */
-  starred?: boolean;
-
-  /**
-   * @description Move a task to become a subtask of another.
-   * To make a subtask a top-level task, you would need a 'move' operation,
-   * which isn't directly supported via a simple `parent: null` update.
-   */
-  parent?: string;
-
-  /**
-   * @description Links associated with the task.
-   */
-  links?: GoogleLink[];
+  // All metadata (priority, isFlagged, url, tags) is now stored in the notes field
 }
 
 /**

--- a/api/types/google-api.ts
+++ b/api/types/google-api.ts
@@ -93,7 +93,11 @@ export interface UpdateTaskRequest {
    */
   completed?: string;
 
-  // All metadata (priority, isFlagged, url, tags) is now stored in the notes field
+  // Metadata fields that will be appended to notes
+  priority?: number;
+  isFlagged?: boolean;
+  url?: string;
+  tags?: string[];
 }
 
 /**


### PR DESCRIPTION
- Updated `createTaskWebhookBodySchema` and `updateTaskWebhookBodySchema` to replace `starred` and `parent` fields with `priority`, `isFlagged`, and `tags`.
- Modified `createTask` and `updateTask` methods in `GoogleTasksService` to handle new metadata fields.
- Implemented `buildNotesWithMetadata` and `extractMetadataFromNotes` functions for structured notes management.
- Updated documentation to reflect changes in webhook payload structure and supported fields.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced support for task metadata fields: priority, flagged status, URL, and tags, now embedded within task notes.
  * Added ability to include and update tags (array of strings) and priority (0-9) for tasks.

* **Bug Fixes**
  * Removed deprecated fields (starred, parent, links) from task creation and update payloads.

* **Documentation**
  * Updated webhook endpoint documentation to reflect new metadata fields and their storage format in notes, with revised examples and clearer descriptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->