### PR TITLE
Refactor task metadata types in webhook schemas and GoogleTasksService

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -94,10 +94,10 @@ const createTaskWebhookBodySchema = z.object({
   title: z.string().min(1).trim(),
   notes: z.string().trim().optional(),
   due: z.string().optional(),
-  priority: z.number().min(0).max(9).optional(),
+  priority: z.string().optional(),
   isFlagged: z.boolean().optional(),
   url: z.string().url().optional(),
-  tags: z.array(z.string()).optional(),
+  tags: z.string().optional(),
 });
 
 const updateTaskWebhookBodySchema = z.object({
@@ -106,10 +106,10 @@ const updateTaskWebhookBodySchema = z.object({
   notes: z.string().trim().optional(),
   due: z.string().optional(),
   status: z.enum(['needsAction', 'completed']).optional(),
-  priority: z.number().min(0).max(9).optional(),
+  priority: z.string().optional(),
   isFlagged: z.boolean().optional(),
   url: z.string().url().optional(),
-  tags: z.array(z.string()).optional(),
+  tags: z.string().optional(),
 });
 
 const deleteTaskWebhookBodySchema = z.object({

--- a/api/services/google-auth.ts
+++ b/api/services/google-auth.ts
@@ -158,7 +158,9 @@ export class GoogleAuthService {
             `Refresh token expired or invalid: ${errorJson.error_description || errorJson.error}`
           );
         } catch {
-          throw new AuthenticationError('Refresh token expired or invalid');
+          throw new AuthenticationError(
+            'Re[webhook] / status=400fresh token expired or invalid'
+          );
         }
       }
 

--- a/api/services/google-tasks.ts
+++ b/api/services/google-tasks.ts
@@ -10,10 +10,10 @@ const DEFAULT_TASK_LIST = '@default';
 const MAX_PAGE_SIZE = 100;
 
 interface TaskMetadata {
-  priority?: number;
+  priority?: string;
   isFlagged?: boolean;
   url?: string;
-  tags?: string[];
+  tags?: string;
 }
 
 /**
@@ -41,9 +41,8 @@ function buildNotesWithMetadata(
     metadataLines.push(`URL: ${metadata.url}`);
   }
 
-  if (metadata.tags && metadata.tags.length > 0) {
-    const tagsString = metadata.tags.map((tag) => `#${tag}`).join(' ');
-    metadataLines.push(`Tags: ${tagsString}`);
+  if (metadata.tags) {
+    metadataLines.push(`Tags: ${metadata.tags}`);
   }
 
   if (metadataLines.length > 0) {
@@ -91,10 +90,7 @@ function extractMetadataFromNotes(notes: string): {
 
     switch (key) {
       case 'Priority': {
-        const parsedPriority = parseInt(value, 10);
-        if (!isNaN(parsedPriority)) {
-          metadata.priority = parsedPriority;
-        }
+        metadata.priority = value;
         break;
       }
       case 'Flagged':
@@ -104,10 +100,7 @@ function extractMetadataFromNotes(notes: string): {
         metadata.url = value;
         break;
       case 'Tags':
-        metadata.tags = value
-          .split(' ')
-          .filter((tag) => tag.startsWith('#'))
-          .map((tag) => tag.substring(1));
+        metadata.tags = value;
         break;
     }
   }
@@ -121,10 +114,10 @@ export class GoogleTasksService {
     title: string,
     notes?: string,
     due?: string,
-    priority?: number,
+    priority?: string,
     isFlagged?: boolean,
     url?: string,
-    tags?: string[]
+    tags?: string
   ): Promise<GoogleTask> {
     const taskData: CreateTaskRequest = {
       title: title || 'New Reminder',
@@ -283,7 +276,7 @@ export class GoogleTasksService {
       updates.priority !== undefined ||
       updates.isFlagged !== undefined ||
       updates.url !== undefined ||
-      (updates.tags && updates.tags.length > 0);
+      updates.tags !== undefined;
 
     if (updates.notes !== undefined || hasMetadata) {
       let finalNotes = updates.notes;

--- a/api/types/google-api.ts
+++ b/api/types/google-api.ts
@@ -94,10 +94,10 @@ export interface UpdateTaskRequest {
   completed?: string;
 
   // Metadata fields that will be appended to notes
-  priority?: number;
+  priority?: string;
   isFlagged?: boolean;
   url?: string;
-  tags?: string[];
+  tags?: string;
 }
 
 /**


### PR DESCRIPTION
- Updated `createTaskWebhookBodySchema` and `updateTaskWebhookBodySchema` to change `priority` and `tags` fields from number and array types to string.
- Modified `TaskMetadata` interface in `GoogleTasksService` to reflect the new types for `priority` and `tags`.
- Adjusted metadata extraction and handling in `extractMetadataFromNotes` and `buildNotesWithMetadata` functions to accommodate the updated types.