### PR TITLE
Remove `createTaskWebhookBodySchema` from API index and update task creation endpoint to directly use `handleCreateTaskWebhook`.

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -90,16 +90,6 @@ const userIdParamSchema = z.object({
   userId: z.string().min(1).trim(),
 });
 
-const createTaskWebhookBodySchema = z.object({
-  title: z.string().min(1).trim(),
-  notes: z.string().trim().optional(),
-  due: z.string().optional(),
-  priority: z.string().optional(),
-  isFlagged: z.boolean().optional(),
-  url: z.string().url().optional(),
-  tags: z.string().optional(),
-});
-
 const updateTaskWebhookBodySchema = z.object({
   taskId: z.string().min(1).trim(),
   title: z.string().min(1).trim().optional(),
@@ -121,7 +111,6 @@ const authCallbackQuerySchema = z.object({
 });
 
 export type UserIdParam = z.infer<typeof userIdParamSchema>;
-export type CreateTaskWebhookBody = z.infer<typeof createTaskWebhookBodySchema>;
 export type UpdateTaskWebhookBody = z.infer<typeof updateTaskWebhookBodySchema>;
 export type DeleteTaskWebhookBody = z.infer<typeof deleteTaskWebhookBodySchema>;
 export type AuthCallbackQuery = z.infer<typeof authCallbackQuerySchema>;
@@ -135,12 +124,7 @@ app.get(
   handleGoogleCallback
 );
 
-app.post(
-  '/webhook/:userId/tasks',
-  zValidator('param', userIdParamSchema),
-  zValidator('json', createTaskWebhookBodySchema),
-  handleCreateTaskWebhook
-);
+app.post('/webhook/:userId/tasks', handleCreateTaskWebhook);
 
 app.put(
   '/webhook/:userId/tasks',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed validation for the task webhook creation endpoint.
  * Streamlined the task webhook creation process by eliminating related schema and type definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->