### PR TITLE
Update task metadata types in webhook schemas and GoogleTasksService

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -94,8 +94,8 @@ const createTaskWebhookBodySchema = z.object({
   title: z.string().min(1).trim(),
   notes: z.string().trim().optional(),
   due: z.string().optional(),
-  priority: z.number().min(0).max(9).optional(),
-  isFlagged: z.boolean().optional(),
+  priority: z.boolean().optional(),
+  isFlagged: z.string().optional(),
   url: z.string().url().optional(),
   tags: z.array(z.string()).optional(),
 });
@@ -106,8 +106,8 @@ const updateTaskWebhookBodySchema = z.object({
   notes: z.string().trim().optional(),
   due: z.string().optional(),
   status: z.enum(['needsAction', 'completed']).optional(),
-  priority: z.number().min(0).max(9).optional(),
-  isFlagged: z.boolean().optional(),
+  priority: z.boolean().optional(),
+  isFlagged: z.string().optional(),
   url: z.string().url().optional(),
   tags: z.array(z.string()).optional(),
 });

--- a/api/services/google-tasks.ts
+++ b/api/services/google-tasks.ts
@@ -10,8 +10,8 @@ const DEFAULT_TASK_LIST = '@default';
 const MAX_PAGE_SIZE = 100;
 
 interface TaskMetadata {
-  priority?: number;
-  isFlagged?: boolean;
+  priority?: boolean;
+  isFlagged?: string;
   url?: string;
   tags?: string[];
 }
@@ -30,11 +30,11 @@ function buildNotesWithMetadata(
   const metadataLines: string[] = [];
 
   if (metadata.priority !== undefined) {
-    metadataLines.push(`Priority: ${metadata.priority}`);
+    metadataLines.push(`Priority: ${metadata.priority ? 'High' : 'Normal'}`);
   }
 
   if (metadata.isFlagged !== undefined) {
-    metadataLines.push(`Flagged: ${metadata.isFlagged ? 'Yes' : 'No'}`);
+    metadataLines.push(`Flagged: ${metadata.isFlagged}`);
   }
 
   if (metadata.url) {
@@ -90,15 +90,11 @@ function extractMetadataFromNotes(notes: string): {
     const value = trimmedLine.substring(separatorIndex + 1).trim();
 
     switch (key) {
-      case 'Priority': {
-        const parsedPriority = parseInt(value, 10);
-        if (!isNaN(parsedPriority)) {
-          metadata.priority = parsedPriority;
-        }
+      case 'Priority':
+        metadata.priority = value === 'High';
         break;
-      }
       case 'Flagged':
-        metadata.isFlagged = value === 'Yes';
+        metadata.isFlagged = value;
         break;
       case 'URL':
         metadata.url = value;
@@ -121,8 +117,8 @@ export class GoogleTasksService {
     title: string,
     notes?: string,
     due?: string,
-    priority?: number,
-    isFlagged?: boolean,
+    priority?: boolean,
+    isFlagged?: string,
     url?: string,
     tags?: string[]
   ): Promise<GoogleTask> {

--- a/api/types/google-api.ts
+++ b/api/types/google-api.ts
@@ -94,8 +94,8 @@ export interface UpdateTaskRequest {
   completed?: string;
 
   // Metadata fields that will be appended to notes
-  priority?: number;
-  isFlagged?: boolean;
+  priority?: boolean;
+  isFlagged?: string;
   url?: string;
   tags?: string[];
 }


### PR DESCRIPTION
- Changed the type of `priority` from `number` to `boolean` and `isFlagged` from `boolean` to `string` in the `createTaskWebhookBodySchema` and `updateTaskWebhookBodySchema`.
- Updated the `TaskMetadata` interface in `GoogleTasksService` to reflect the new types for `priority` and `isFlagged`.
- Adjusted the logic in `buildNotesWithMetadata` and `extractMetadataFromNotes` to accommodate the new types for metadata handling.