### PR TITLE
Update task metadata types in webhook schemas and GoogleTasksService …

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -97,7 +97,7 @@ const createTaskWebhookBodySchema = z.object({
   priority: z.boolean().optional(),
   isFlagged: z.string().optional(),
   url: z.string().url().optional(),
-  tags: z.array(z.string()).optional(),
+  tags: z.string().optional(),
 });
 
 const updateTaskWebhookBodySchema = z.object({
@@ -109,7 +109,7 @@ const updateTaskWebhookBodySchema = z.object({
   priority: z.boolean().optional(),
   isFlagged: z.string().optional(),
   url: z.string().url().optional(),
-  tags: z.array(z.string()).optional(),
+  tags: z.string().optional(),
 });
 
 const deleteTaskWebhookBodySchema = z.object({

--- a/api/services/google-tasks.ts
+++ b/api/services/google-tasks.ts
@@ -13,7 +13,7 @@ interface TaskMetadata {
   priority?: boolean;
   isFlagged?: string;
   url?: string;
-  tags?: string[];
+  tags?: string;
 }
 
 /**
@@ -41,9 +41,8 @@ function buildNotesWithMetadata(
     metadataLines.push(`URL: ${metadata.url}`);
   }
 
-  if (metadata.tags && metadata.tags.length > 0) {
-    const tagsString = metadata.tags.map((tag) => `#${tag}`).join(' ');
-    metadataLines.push(`Tags: ${tagsString}`);
+  if (metadata.tags) {
+    metadataLines.push(`Tags: ${metadata.tags}`);
   }
 
   if (metadataLines.length > 0) {
@@ -100,10 +99,7 @@ function extractMetadataFromNotes(notes: string): {
         metadata.url = value;
         break;
       case 'Tags':
-        metadata.tags = value
-          .split(' ')
-          .filter((tag) => tag.startsWith('#'))
-          .map((tag) => tag.substring(1));
+        metadata.tags = value;
         break;
     }
   }
@@ -120,7 +116,7 @@ export class GoogleTasksService {
     priority?: boolean,
     isFlagged?: string,
     url?: string,
-    tags?: string[]
+    tags?: string
   ): Promise<GoogleTask> {
     const taskData: CreateTaskRequest = {
       title: title || 'New Reminder',
@@ -279,7 +275,7 @@ export class GoogleTasksService {
       updates.priority !== undefined ||
       updates.isFlagged !== undefined ||
       updates.url !== undefined ||
-      (updates.tags && updates.tags.length > 0);
+      updates.tags !== undefined;
 
     if (updates.notes !== undefined || hasMetadata) {
       let finalNotes = updates.notes;

--- a/api/types/google-api.ts
+++ b/api/types/google-api.ts
@@ -97,7 +97,7 @@ export interface UpdateTaskRequest {
   priority?: boolean;
   isFlagged?: string;
   url?: string;
-  tags?: string[];
+  tags?: string;
 }
 
 /**


### PR DESCRIPTION
…to use a single string for tags instead of an array. This change simplifies the handling of tags in the API and related services.