### PR TITLE
Implement sync ID mapping for Apple Reminders and Google Tasks

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -97,22 +97,33 @@ const createTaskWebhookBodySchema = z.object({
   priority: z.boolean().optional(),
   url: z.string().optional(),
   tags: z.string().optional(),
+  syncId: z.string().optional(),
 });
 
-const updateTaskWebhookBodySchema = z.object({
-  taskId: z.string().min(1).trim(),
-  title: z.string().min(1).trim().optional(),
-  notes: z.string().trim().optional(),
-  due: z.string().optional(),
-  status: z.enum(['needsAction', 'completed']).optional(),
-  priority: z.boolean().optional(),
-  url: z.string().optional(),
-  tags: z.string().optional(),
-});
+const updateTaskWebhookBodySchema = z
+  .object({
+    taskId: z.string().min(1).trim().optional(),
+    syncId: z.string().optional(),
+    title: z.string().min(1).trim().optional(),
+    notes: z.string().trim().optional(),
+    due: z.string().optional(),
+    status: z.enum(['needsAction', 'completed']).optional(),
+    priority: z.boolean().optional(),
+    url: z.string().optional(),
+    tags: z.string().optional(),
+  })
+  .refine((data) => data.taskId || data.syncId, {
+    message: 'Either taskId or syncId must be provided',
+  });
 
-const deleteTaskWebhookBodySchema = z.object({
-  taskId: z.string().min(1).trim(),
-});
+const deleteTaskWebhookBodySchema = z
+  .object({
+    taskId: z.string().min(1).trim().optional(),
+    syncId: z.string().optional(),
+  })
+  .refine((data) => data.taskId || data.syncId, {
+    message: 'Either taskId or syncId must be provided',
+  });
 
 const authCallbackQuerySchema = z.object({
   code: z.string().min(1),

--- a/api/services/google-tasks.ts
+++ b/api/services/google-tasks.ts
@@ -36,6 +36,7 @@ interface TaskMetadata {
   priority?: boolean;
   url?: string;
   tags?: string;
+  syncId?: string;
 }
 
 /**
@@ -55,13 +56,16 @@ function buildNotesWithMetadata(
     metadataLines.push(`Priority: ${metadata.priority ? 'High' : 'Normal'}`);
   }
 
-
   if (metadata.url) {
     metadataLines.push(`URL: ${metadata.url}`);
   }
 
   if (metadata.tags) {
     metadataLines.push(`Tags: ${metadata.tags}`);
+  }
+
+  if (metadata.syncId) {
+    metadataLines.push(`SyncID: ${metadata.syncId}`);
   }
 
   if (metadataLines.length > 0) {
@@ -117,6 +121,9 @@ function extractMetadataFromNotes(notes: string): {
       case 'Tags':
         metadata.tags = value;
         break;
+      case 'SyncID':
+        metadata.syncId = value;
+        break;
     }
   }
 
@@ -131,7 +138,8 @@ export class GoogleTasksService {
     due?: string,
     priority?: boolean,
     url?: string,
-    tags?: string
+    tags?: string,
+    syncId?: string
   ): Promise<GoogleTask> {
     const taskData: CreateTaskRequest = {
       title: title || 'New Reminder',
@@ -141,6 +149,7 @@ export class GoogleTasksService {
       priority,
       url,
       tags,
+      syncId,
     });
 
     if (finalNotes) taskData.notes = finalNotes;
@@ -623,5 +632,38 @@ export class GoogleTasksService {
     } while (pageToken);
 
     return allTasks;
+  }
+
+  /**
+   * Extract metadata from a Google Task
+   * Useful for getting syncId and other metadata from tasks
+   */
+  extractTaskMetadata(task: GoogleTask): TaskMetadata {
+    if (!task.notes) return {};
+    const { metadata } = extractMetadataFromNotes(task.notes);
+    return metadata;
+  }
+
+  /**
+   * Find a task by sync ID
+   * Searches through all tasks to find one with matching sync ID
+   */
+  async findTaskBySyncId(
+    accessToken: string,
+    syncId: string
+  ): Promise<GoogleTask | null> {
+    const allTasks = await this.listAllTasks(accessToken, {
+      showCompleted: true,
+      showHidden: true,
+    });
+
+    for (const task of allTasks) {
+      const metadata = this.extractTaskMetadata(task);
+      if (metadata.syncId === syncId) {
+        return task;
+      }
+    }
+
+    return null;
   }
 }

--- a/api/types/user.ts
+++ b/api/types/user.ts
@@ -8,10 +8,17 @@ export interface UserProfile {
   picture: string;
 }
 
+export interface TaskMapping {
+  googleTaskId: string;
+  createdAt: string;
+  lastUpdated: string;
+}
+
 export interface User {
   id: string;
   tokens: UserTokens;
-  syncedTaskIds: string[];
+  syncedTaskIds: string[]; // Keep for backward compatibility
+  taskMappings?: Record<string, TaskMapping>; // New mapping structure
   profile: UserProfile;
   lastSyncTime?: string; // RFC 3339 timestamp of last sync
 }

--- a/docs/webhook-endpoints.example.md
+++ b/docs/webhook-endpoints.example.md
@@ -35,13 +35,23 @@ curl -X POST https://your-domain.com/api/webhook/user123/tasks \
     "url": "https://github.com/user/repo/pull/123",
     "tags": ["code-review", "urgent"]
   }'
+
+# Example - Create with custom sync ID (for Apple Reminders):
+curl -X POST https://your-domain.com/api/webhook/user123/tasks \
+  -H "Content-Type: application/json" \
+  -d '{
+    "title": "Buy groceries",
+    "notes": "Remember milk and eggs",
+    "syncId": "sync_apple_reminder_12345"
+  }'
 {
   "message": "Task created successfully.",
   "taskId": "task-id-123",
+  "syncId": "sync_1706697600000",
   "task": {
     "id": "task-id-123",
     "title": "Review pull request",
-    "notes": "Check the new implementation\n\n--- Metadata ---\nPriority: High\nURL: https://github.com/user/repo/pull/123\nTags: #code-review #urgent",
+    "notes": "Check the new implementation\n\n--- Metadata ---\nPriority: High\nURL: https://github.com/user/repo/pull/123\nTags: #code-review #urgent\nSyncID: sync_1706697600000",
     "status": "needsAction",
     "kind": "tasks#task",
     "updated": "2024-01-31T10:00:00.000Z"
@@ -121,6 +131,15 @@ curl -X PUT https://your-domain.com/api/webhook/user123/tasks \
     "tags": ["urgent", "high-priority", "review"]
   }'
 
+# Example 9: Update using sync ID (for Apple Reminders):
+curl -X PUT https://your-domain.com/api/webhook/user123/tasks \
+  -H "Content-Type: application/json" \
+  -d '{
+    "syncId": "sync_apple_reminder_12345",
+    "title": "Buy groceries - Updated",
+    "status": "completed"
+  }'
+
 # Response:
 {
   "message": "Task updated successfully.",
@@ -147,6 +166,13 @@ curl -X DELETE https://your-domain.com/api/webhook/user123/tasks \
   -H "Content-Type: application/json" \
   -d '{
     "taskId": "task-id-123"
+  }'
+
+# Example - Delete using sync ID (for Apple Reminders):
+curl -X DELETE https://your-domain.com/api/webhook/user123/tasks \
+  -H "Content-Type: application/json" \
+  -d '{
+    "syncId": "sync_apple_reminder_12345"
   }'
 
 # Response:
@@ -182,22 +208,33 @@ curl -X POST https://your-domain.com/api/webhook/user123 \
   - PUT for update
   - DELETE for delete
 - All endpoints require a valid `userId` parameter
-- Update and Delete endpoints now require `taskId` to be passed in the request body (JSON)
+- Update and Delete endpoints accept either `taskId` or `syncId` in the request body (JSON)
 - Update endpoint allows partial updates (only send fields you want to change)
 
 ### Metadata Storage
-- All metadata (priority, url, tags) is stored in the notes field
+
+- All metadata (priority, url, tags, syncId) is stored in the notes field
 - Metadata is appended in a structured format for easy parsing:
+
   ```
   [User's notes]
-  
+
   --- Metadata ---
   Priority: High
   URL: https://example.com
   Tags: #tag1 #tag2
+  SyncID: sync_1706697600000
   ```
 
+### Sync ID Usage
+
+- When creating a task from Apple Reminders, include a `syncId` in the request
+- If no `syncId` is provided, one will be generated automatically
+- Use the `syncId` to update or delete tasks without knowing the Google Task ID
+- The `syncId` is stored in the task's notes metadata and persists across syncs
+
 ### Supported Fields
+
 - Update endpoint supports:
   - `title`: Task title
   - `notes`: Task description/notes (metadata will be appended)


### PR DESCRIPTION
- Add sync ID support to create, update, and delete operations
- Store sync ID in Google Tasks notes metadata for persistence
- Update User type to support future task mappings
- Add helper methods to find tasks by sync ID
- Update webhook handlers to accept either taskId or syncId
- Update documentation with sync ID usage examples
- Fix TypeScript and ESLint errors

This allows Apple Reminders to maintain consistent references to Google Tasks without needing to store Google Task IDs on the Apple side.