### PR TITLE
Refactor task priority handling to use string enums

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -94,7 +94,7 @@ const createTaskWebhookBodySchema = z.object({
   title: z.string().min(1).trim(),
   notes: z.string().trim().optional(),
   due: z.string().optional(),
-  priority: z.number().int().min(0).max(3).optional(), // 0: None, 1: Low, 2: Medium, 3: High
+  priority: z.enum(['None', 'Low', 'Medium', 'High']).optional(),
   url: z.string().optional(),
   tags: z.string().optional(),
   syncId: z.string().optional(),
@@ -108,7 +108,7 @@ const updateTaskWebhookBodySchema = z
     title: z.string().min(1).trim().optional(),
     notes: z.string().trim().optional(),
     due: z.string().optional(),
-    priority: z.number().int().min(0).max(3).optional(), // 0: None, 1: Low, 2: Medium, 3: High
+    priority: z.enum(['None', 'Low', 'Medium', 'High']).optional(),
     isCompleted: z.boolean().optional(),
     url: z.string().optional(),
     tags: z.string().optional(),

--- a/api/services/google-tasks.ts
+++ b/api/services/google-tasks.ts
@@ -9,13 +9,7 @@ const TASKS_API_BASE_URL = 'https://tasks.googleapis.com/tasks/v1';
 const DEFAULT_TASK_LIST = '@default';
 const MAX_PAGE_SIZE = 100;
 
-const PRIORITY_NAMES = ['None', 'Low', 'Medium', 'High'] as const;
-const PRIORITY_VALUES: Record<string, number> = {
-  None: 0,
-  Low: 1,
-  Medium: 2,
-  High: 3,
-} as const;
+type PriorityValue = 'None' | 'Low' | 'Medium' | 'High';
 
 /**
  * Parses various date formats and returns RFC 3339 format
@@ -41,7 +35,7 @@ function parseToRFC3339(dateString: string | undefined): string | undefined {
 }
 
 interface TaskMetadata {
-  priority?: number; // 0: None, 1: Low, 2: Medium, 3: High
+  priority?: PriorityValue;
   url?: string;
   tags?: string;
   syncId?: string;
@@ -61,9 +55,7 @@ function buildNotesWithMetadata(
   const metadataLines: string[] = [];
 
   if (metadata.priority !== undefined) {
-    metadataLines.push(
-      `Priority: ${PRIORITY_NAMES[metadata.priority] || 'None'}`
-    );
+    metadataLines.push(`Priority: ${metadata.priority}`);
   }
 
   if (metadata.url) {
@@ -123,7 +115,7 @@ function extractMetadataFromNotes(notes: string): {
 
     switch (key) {
       case 'Priority':
-        metadata.priority = PRIORITY_VALUES[value] ?? 0;
+        metadata.priority = value as PriorityValue;
         break;
       case 'URL':
         metadata.url = value;
@@ -146,7 +138,7 @@ export class GoogleTasksService {
     title: string,
     notes?: string,
     due?: string,
-    priority?: number,
+    priority?: PriorityValue,
     url?: string,
     tags?: string,
     syncId?: string

--- a/api/types/google-api.ts
+++ b/api/types/google-api.ts
@@ -94,7 +94,7 @@ export interface UpdateTaskRequest {
   completed?: string;
 
   // Metadata fields that will be appended to notes
-  priority?: number; // 0: None, 1: Low, 2: Medium, 3: High
+  priority?: 'None' | 'Low' | 'Medium' | 'High';
   url?: string;
   tags?: string;
 }

--- a/docs/apple-reminders-google-tasks-sync-mapping.md
+++ b/docs/apple-reminders-google-tasks-sync-mapping.md
@@ -7,34 +7,34 @@ This document explains how properties are mapped between Apple Reminders and Goo
 ### 1. **Priority Status**
 
 - **Apple Reminders**: `priority` (0-9 scale)
-- **Google Tasks**: Stored in notes metadata as priority (0-3)
-- **Mapping**: Priority values mapped as follows:
-  - 0: None
-  - 1: Low
-  - 2: Medium
-  - 3: High
+|- **Google Tasks**: Stored in notes metadata as priority ('None', 'Low', 'Medium', 'High')
+|- **Mapping**: Priority values mapped as follows:
+  - 0: 'None'
+  - 1: 'Low'
+  - 2: 'Medium'
+  - 3: 'High'
 
 ```javascript
 // Apple Reminders → Google Tasks
-// Map Apple's 0-9 scale to 0-3 scale
+// Map Apple's 0-9 scale to string scale
 const mapApplePriority = (applePriority) => {
-  if (applePriority === 0) return 0; // None
-  if (applePriority <= 3) return 1; // Low
-  if (applePriority <= 6) return 2; // Medium
-  return 3; // High (7-9)
+  if (applePriority === 0) return 'None';
+  if (applePriority <= 3) return 'Low';
+  if (applePriority <= 6) return 'Medium';
+  return 'High'; // 7-9
 };
 
 // Google Tasks → Apple Reminders
-// Map 0-3 scale to Apple's 0-9 scale
+// Map string scale to Apple's 0-9 scale
 const mapGooglePriority = (googlePriority) => {
   switch (googlePriority) {
-    case 0:
+    case 'None':
       return 0; // None
-    case 1:
+    case 'Low':
       return 3; // Low
-    case 2:
+    case 'Medium':
       return 5; // Medium
-    case 3:
+    case 'High':
       return 9; // High
     default:
       return 0;
@@ -107,12 +107,12 @@ if (googleTask.links && googleTask.links.length > 0) {
 ```typescript
 // When syncing from Apple Reminders to Google Tasks
 const createGoogleTaskFromAppleReminder = async (reminder: AppleReminder) => {
-  // Map Apple's 0-9 priority to 0-3 scale
-  const mapPriority = (applePriority: number): number => {
-    if (applePriority === 0) return 0; // None
-    if (applePriority <= 3) return 1; // Low
-    if (applePriority <= 6) return 2; // Medium
-    return 3; // High (7-9)
+  // Map Apple's 0-9 priority to string scale
+  const mapPriority = (applePriority: number): string =e {
+    if (applePriority === 0) return 'None'; // None
+    if (applePriority c= 3) return 'Low'; // Low
+    if (applePriority c= 6) return 'Medium'; // Medium
+    return 'High'; // High (7-9)
   };
 
   const task = await googleTasksService.createTask(
@@ -177,7 +177,7 @@ const createAppleReminderFromGoogleTask = (task: GoogleTask) => {
     dueDate: task.due ? new Date(task.due) : undefined,
     isCompleted: task.status === 'completed',
     completionDate: task.completed ? new Date(task.completed) : undefined,
-    priority: mapGooglePriority(extractedMetadata.priority || 0),
+priority: mapGooglePriority(extractedMetadata.priority || 'None'),
     url: task.links?.[0]?.link,
     parentId: task.parent,
   };
@@ -190,8 +190,8 @@ const createAppleReminderFromGoogleTask = (task: GoogleTask) => {
 
 1. **Priority Handling**: Priority mapping between systems:
    - Apple Reminders: 0-9 scale
-   - Google Tasks: 0-3 scale (0=None, 1=Low, 2=Medium, 3=High)
-   - Mapping: 0→0, 1-3→1, 4-6→2, 7-9→3
+   - Google Tasks: String scale ('None', 'Low', 'Medium', 'High')
+   - Mapping: 0→'None', 1-3→'Low', 4-6→'Medium', 7-9→'High'
    - The priority is stored in the notes metadata section
 
 2. **URL Handling**:

--- a/docs/webhook-endpoints.example.md
+++ b/docs/webhook-endpoints.example.md
@@ -20,7 +20,7 @@ curl -X POST https://your-domain.com/api/webhook/user123/tasks \
     "title": "Complete project documentation",
     "notes": "Update README and API docs",
     "due": "2024-12-31T23:59:59Z",
-    "priority": 2,
+    "priority": "Medium",
     "url": "https://github.com/user/project",
     "tags": ["documentation", "important"]
   }'
@@ -31,7 +31,7 @@ curl -X POST https://your-domain.com/api/webhook/user123/tasks \
   -d '{
     "title": "Review pull request",
     "notes": "Check the new implementation",
-    "priority": 3,
+    "priority": "High",
     "url": "https://github.com/user/repo/pull/123",
     "tags": ["code-review", "urgent"]
   }'
@@ -111,7 +111,7 @@ curl -X PUT https://your-domain.com/api/webhook/user123/tasks \
   -H "Content-Type: application/json" \
   -d '{
     "taskId": "task-id-123",
-    "priority": 3  # High priority
+    "priority": "High"
   }'
 
 # Example 6: Update task URL (sync Apple Reminders URL)
@@ -128,7 +128,7 @@ curl -X PUT https://your-domain.com/api/webhook/user123/tasks \
   -d '{
     "taskId": "task-id-123",
     "title": "Updated task title",
-    "priority": 3
+    "priority": "High"
   }'
 
 # Example 8: Update priority and tags
@@ -136,7 +136,7 @@ curl -X PUT https://your-domain.com/api/webhook/user123/tasks \
   -H "Content-Type: application/json" \
   -d '{
     "taskId": "task-id-123",
-    "priority": 3,
+    "priority": "High",
     "tags": ["urgent", "high-priority", "review"]
   }'
 
@@ -249,7 +249,7 @@ curl -X POST https://your-domain.com/api/webhook/user123 \
   - `notes`: Task description/notes (metadata will be appended)
   - `due`: Due date (RFC 3339 format)
   - `isCompleted`: Boolean to mark task as completed or not (maps to status)
-  - `priority`: Priority level (0-3) - stored in notes
+  - `priority`: Priority level ('None', 'Low', 'Medium', 'High') - stored in notes
   - `url`: URL - stored in notes
   - `tags`: Array of tags - stored in notes
 - Create endpoint supports:
@@ -257,7 +257,7 @@ curl -X POST https://your-domain.com/api/webhook/user123 \
   - `notes`: Task description/notes
   - `due`: Due date (RFC 3339 format)
   - `isCompleted`: Boolean to create task as completed (default: false)
-  - `priority`: Priority level (0-3) - stored in notes
+  - `priority`: Priority level ('None', 'Low', 'Medium', 'High') - stored in notes
   - `url`: URL associated with the task - stored in notes
   - `tags`: Array of tags for categorization - stored in notes
 - Delete endpoint is fully implemented - permanently removes tasks from Google Tasks


### PR DESCRIPTION
- Updated task webhook schemas to replace numeric priority with string enums ('None', 'Low', 'Medium', 'High').
- Modified related service and type definitions to reflect the new priority structure.
- Adjusted documentation and examples to align with the updated priority mapping.
- This change enhances clarity and consistency in priority representation across the application.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Task priority is now represented using descriptive string values ('None', 'Low', 'Medium', 'High') instead of numeric levels throughout the app and API.

* **Documentation**
  * Updated all relevant documentation and code examples to reflect the new string-based priority values in API requests, sync mappings, and usage instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->