### PR TITLE
Redirect root path to /api

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "redirects": [
     {
       "source": "/",
-      "destination": "/api",
+      "destination": "/api/",
       "permanent": false
     }
   ],


### PR DESCRIPTION
- Add redirect from / to /api in vercel.json
- Use 302 temporary redirect for better UX
- Maintain existing API routing with rewrites
- Landing page now accessible at /api instead of /

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Implemented a temporary redirect from the root path (/) to /api/.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->